### PR TITLE
Amending README.md to reflect orgID requirements for replay_url.sql

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,8 @@ This dbt package contains models, macros, seeds, and tests for [Fullstory](https
 | fullstory_event_types | A list of event types to auto-generate rollups for in the `users` and `sessions` model. |
 
 > We **highly recommend** using `fullstory_events_database`, `fullstory_events_schema` and `fullstory_events_table` to indicate the location of the Fullstory events table that is synced from Data Destinations. Using these variables allow you to use a separate database or schema for the Fullstory events table than your dbt package.
+>
+> We **highly recommend** utilizing the Fullstory OrgID as the `target` name in `profiles.yml`. This will not only make Umbrella configurations easier but will also allow for `replay_url.sql` to function as intended.
 
 #### Example use of vars for Big Query
 ```yaml


### PR DESCRIPTION
Adding a callout for users in regards to profiles.yml to use the Fullstory OrgID so any macros or SQL relying on the target will function as intended.